### PR TITLE
Redesigned high-pass layer

### DIFF
--- a/src/CustomDataLoader.py
+++ b/src/CustomDataLoader.py
@@ -47,11 +47,12 @@ class DataProcesser():
     
     def show_tensor_image(self, img): 
         if len(img.shape) == 4:
-            for idx in range(img.shape[0]):
-                img = img[idx, :, : ,:]
-                img = self.rev_trans(img)
-                plt.subplot(1, img.shape[0], idx)
-                plt.imshow(img)
+            b, c, h, w = img.shape
+            for idx in range(b):
+                t_img = img[idx, :, : ,:]
+                t_img = self.rev_trans(t_img)
+                plt.subplot(1, b, idx + 1)
+                plt.imshow(t_img)
             
         else:
             img = self.rev_trans(img)

--- a/src/FreqEncoder.py
+++ b/src/FreqEncoder.py
@@ -2,6 +2,34 @@ import torch
 from torch import nn
 import math
 from src.Configueration import VitConfig
+from src.CustomDataLoader import DataProcesser
+
+# def show_image(img_tensor):
+#     printer = DataProcesser()
+#     printer.show_tensor_image(img_tensor)
+
+class PatchEmbadding(nn.Module):
+    def __init__(self, config = VitConfig()):
+        super().__init__()
+        self.num_channels = config.num_channels
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+        self.num_patches = config.num_patchs
+        self.hidden_size = config.hidden_size
+        self.device = config.device
+        
+    def forward(self, batch):
+        # show_image(batch)
+        b, c, h, w = batch.shape
+        hidden_states = torch.zeros((b, self.num_patches, self.hidden_size), device = self.device)
+        patch_len = int(h/self.patch_size)
+        for b_idx in range(b):
+            for i in range(patch_len):
+                for j in range(patch_len):
+                    tmp_patch = batch[b_idx, :, i*self.patch_size:(i+1)*self.patch_size, j*self.patch_size:(j+1)*self.patch_size].flatten()
+                    hidden_states[b_idx, i*patch_len+j, :] = tmp_patch
+        
+        return hidden_states
 
 class HighPass(nn.Module):
     def __init__(self, config = VitConfig()):
@@ -22,25 +50,29 @@ class HighPass(nn.Module):
         return highpassed
         
     def forward(self, batch):
+        # show_image(batch[0:14])
         highpassed = self.highpass(batch)
+        # show_image(highpassed[0:14])
         return highpassed
 
-class PatchEmbadding(nn.Module):
+class LocalHighPass(nn.Module):
     def __init__(self, config = VitConfig()):
         super().__init__()
-        self.num_channels = config.num_channels
-        self.image_size = config.image_size
-        self.patch_size = config.patch_size
-        self.num_patches = config.num_patchs
         self.hidden_size = config.hidden_size
+        self.num_channels = config.num_channels
+        self.patch_size = config.patch_size
+        self.num_patchs = config.num_patchs
+        self.highpass = HighPass()
+           
+    def forward(self, hidden_states):
+        batch_num = hidden_states.shape[0]
+        reshape = torch.zeros((self.num_patchs, self.num_channels, self.patch_size, self.patch_size))
+        for b_idx in range(batch_num):
+            for p_idx in range(self.num_patchs):
+                reshape[p_idx, :, :, :] = hidden_states[b_idx, p_idx, :].reshape(shape = (self.num_channels, self.patch_size, self.patch_size))
 
-        self.projection = nn.Conv2d(self.num_channels, self.hidden_size, kernel_size = self.patch_size, stride = self.patch_size)
-        self.position_embaddings = nn.Parameter(torch.randn(1, self.num_patches, self.hidden_size))
-        
-    def forward(self, batch):
-        hidden_states = self.projection(batch).flatten(2).transpose(1, 2)
-        hidden_states = hidden_states + self.position_embaddings
-        
+            hidden_states[b_idx, :, :] = self.highpass(reshape).flatten(1)
+    
         return hidden_states
 
 class MSAttention(nn.Module):
@@ -51,6 +83,8 @@ class MSAttention(nn.Module):
         self.num_attention_heads = config.num_attention_heads
         self.head_size = int(self.hidden_size/self.num_attention_heads)
         self.all_head_size = self.num_attention_heads * self.head_size
+        
+        self.position_embaddings = nn.Parameter(torch.randn(1, self.num_patchs, self.hidden_size))
         
         self.qeury = nn.Linear(self.hidden_size, self.all_head_size, bias = True)
         self.key = nn.Linear(self.hidden_size, self.all_head_size, bias = True)
@@ -70,7 +104,10 @@ class MSAttention(nn.Module):
         
         return context_to_embaddings
     
-    def forward(self, hidden_states):
+    def forward(self, hidden_states, first_block = False):
+        if first_block:
+            hidden_states = hidden_states + self.position_embaddings
+            
         mixed_key = self.key(hidden_states)
         mixed_value = self.value(hidden_states)
         mixed_query = self.qeury(hidden_states)
@@ -103,16 +140,19 @@ class MLP(nn.Module):
         return x
 
 class EncoderBlock(nn.Module):
-    def __init__(self, config = VitConfig()):
+    def __init__(self, config = VitConfig(), first_block = False):
         super().__init__()
+        self.highpass = LocalHighPass()
         self.attention = MSAttention()
         self.mlp = MLP()
         self.layernorm_before = nn.LayerNorm(config.hidden_size)
         self.layernorm_att = nn.LayerNorm(config.hidden_size)
         self.layernorm_mlp = nn.LayerNorm(config.hidden_size)
+        self.first_block = first_block
         
     def forward(self, hidden_states):
-        self_attention_output = self.attention(self.layernorm_before(hidden_states))
+        hidden_states = self.highpass(hidden_states)
+        self_attention_output = self.attention(self.layernorm_before(hidden_states), self.first_block)
         hidden_states = hidden_states + self.layernorm_att(self_attention_output)
         
         mlp_output = self.mlp(hidden_states)
@@ -123,15 +163,15 @@ class EncoderBlock(nn.Module):
 class VitEncoder(nn.Module):
     def __init__(self, config = VitConfig()):
         super().__init__()
-        self.high_pass_filter = HighPass()
         self.patch_embaddings = PatchEmbadding()
         self.blocks = nn.ModuleList([])
+        self.blocks.append(EncoderBlock(first_block = True))
         for _ in range(config.num_hidden_layers):
             block = EncoderBlock()
             self.blocks.append(block)
             
     def forward(self, batch):
-        x = self.patch_embaddings(self.high_pass_filter(batch))
+        x = self.patch_embaddings(batch)
         for block in self.blocks:
             x = block(x)
         

--- a/src/HighFreqVit.py
+++ b/src/HighFreqVit.py
@@ -6,7 +6,6 @@ from src.Configueration import VitConfig
 from src import FreqEncoder
 from transformers import ViTModel
 
-
 class CrossAttention(FreqEncoder.MSAttention):
     def __init__(self, config = VitConfig()):
         super().__init__()


### PR DESCRIPTION
 Re designed the high-pass layer to be placed between encoder blocks. 

 Especially for the first block, I added the position embaddings right before the first attention module instead of right after patch embaddings, that we can expect the FAD process during first local high-pass filtering ( the stream of first encoder block looks like this. Img -> patch embaddings (without positional embaddings) -> local high-pass filtering -> adding positional embadding -> self-attention -> --- )
 If you use the annotation at FreqEncoder.py, line:7-9, 22, 53, 55.  You can see the patches of the first line (14 patches) to look how local high-pass filtering runs. (you might use batch num = 1 to see in better way)
 I've checked the load of the whole model, it seems quite heavier than before(It takes like 50% more running times). I propose to reduce some encoder block numbers or whatever you thinks. (because I just follow the same parameter of original ViT model of pre-trained one)